### PR TITLE
[codex] update PostgreSQL 16 and 17 images and README

### DIFF
--- a/16/Dockerfile
+++ b/16/Dockerfile
@@ -1,5 +1,5 @@
 # build stage
-FROM postgres:16.4 AS builder
+FROM postgres:16.13 AS builder
 
 RUN rm -f /etc/apt/apt.conf.d/docker-clean; echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
@@ -10,19 +10,18 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     git \
     postgresql-server-dev-16 
 
-RUN git clone https://github.com/sraoss/pg_ivm.git /usr/src/pg_ivm
+RUN git clone --branch v1.13 --depth 1 https://github.com/sraoss/pg_ivm.git /usr/src/pg_ivm
 
 RUN cd /usr/src/pg_ivm && \
-    git checkout v1.9 && \
     make USE_PGXS=1 && \
     make USE_PGXS=1 install
 
 # runtime stage
-FROM postgres:16.4
+FROM postgres:16.13
 
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \
-    apt-get update && \ 
+    apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/17/Dockerfile
+++ b/17/Dockerfile
@@ -1,0 +1,38 @@
+# build stage
+FROM postgres:17beta3 AS builder
+
+RUN rm -f /etc/apt/apt.conf.d/docker-clean; echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update && apt-get install -y \
+    build-essential \
+    libpq-dev \
+    git \
+    postgresql-server-dev-17
+
+RUN git clone https://github.com/sraoss/pg_ivm.git /usr/src/pg_ivm
+
+RUN cd /usr/src/pg_ivm && \
+    git checkout v1.9 && \
+    make USE_PGXS=1 && \
+    make USE_PGXS=1 install
+
+# runtime stage
+FROM postgres:17beta3
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update && \ 
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p '/usr/lib/postgresql/17/lib' && \
+    mkdir -p '/usr/share/postgresql/17/extension' && \
+    mkdir -p '/usr/lib/postgresql/17/lib/bitcode/pg_ivm'
+
+COPY --from=builder /usr/lib/postgresql/17/lib/pg_ivm.so /usr/lib/postgresql/17/lib/pg_ivm.so
+COPY --from=builder /usr/share/postgresql/17/extension/pg_ivm* /usr/share/postgresql/17/extension/
+COPY --from=builder /usr/lib/postgresql/17/lib/bitcode/pg_ivm/* /usr/lib/postgresql/17/lib/bitcode/pg_ivm/
+COPY --from=builder /usr/lib/postgresql/17/lib/bitcode/pg_ivm.index.bc /usr/lib/postgresql/17/lib/bitcode/pg_ivm.index.bc
+
+COPY init-db.sh /docker-entrypoint-initdb.d/

--- a/17/Dockerfile
+++ b/17/Dockerfile
@@ -1,5 +1,5 @@
 # build stage
-FROM postgres:17beta3 AS builder
+FROM postgres:17.9 AS builder
 
 RUN rm -f /etc/apt/apt.conf.d/docker-clean; echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
@@ -10,19 +10,18 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     git \
     postgresql-server-dev-17
 
-RUN git clone https://github.com/sraoss/pg_ivm.git /usr/src/pg_ivm
+RUN git clone --branch v1.14 --depth 1 https://github.com/sraoss/pg_ivm.git /usr/src/pg_ivm
 
 RUN cd /usr/src/pg_ivm && \
-    git checkout v1.9 && \
     make USE_PGXS=1 && \
     make USE_PGXS=1 install
 
 # runtime stage
-FROM postgres:17beta3
+FROM postgres:17.9
 
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \
-    apt-get update && \ 
+    apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/17/init-db.sh
+++ b/17/init-db.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-EOSQL
+    CREATE EXTENSION pg_ivm;
+EOSQL

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,35 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+This repository packages `pg_ivm` into PostgreSQL Docker images. Version-specific files live under `16/` and `17/`. Each directory currently contains `init-db.sh`, which runs during container initialization and creates the `pg_ivm` extension. The root [`README.md`](/home/eiji/git/pg_ivm/README.md) documents image usage and example container startup commands.
+
+## Build, Test, and Development Commands
+Use Docker to build and validate changes.
+
+- `docker build -t pg_ivm:local 17` builds the PostgreSQL 17 image from the `17/` directory.
+- `docker build -t pg_ivm:local 16` builds the PostgreSQL 16 image from the `16/` directory.
+- `docker run --rm -e POSTGRES_PASSWORD=postgres pg_ivm:local` starts a container and runs the init script.
+- `docker exec -it <container> psql -U postgres -d postgres -c "\\dx"` verifies that `pg_ivm` is installed.
+
+Run the same checks for every version directory you touch.
+
+## Coding Style & Naming Conventions
+Shell scripts should remain simple and portable:
+
+- Use `#!/bin/bash` with `set -e`.
+- Keep indentation consistent with existing scripts; current files use four spaces inside the SQL heredoc.
+- Prefer clear, lowercase file names such as `init-db.sh`.
+- Keep SQL initialization idempotent where possible and avoid adding unrelated setup logic.
+
+## Testing Guidelines
+There is no automated test suite in this repository. Validation is done by building the image and confirming that the extension is available in a fresh container. For any change to initialization logic, test the affected PostgreSQL version and confirm `CREATE EXTENSION pg_ivm;` succeeds without manual intervention.
+
+## Commit & Pull Request Guidelines
+Recent commit messages are short and release-oriented, for example: `support postgresql17beta3 + pg_ivm1.9` and `fix pg_ivm version`. Follow that style: concise, imperative or descriptive, and scoped to one change. Pull requests should include:
+
+- the PostgreSQL and `pg_ivm` versions affected
+- the exact build and verification commands used
+- any image tag changes reflected in `README.md`
+
+## Version Update Notes
+When adding support for a new PostgreSQL release, create a matching top-level directory such as `18/`, copy the init script pattern, and keep behavior aligned across supported versions unless a version-specific difference is required.

--- a/README.ja.md
+++ b/README.ja.md
@@ -1,0 +1,76 @@
+# pg_ivm 用 Dockerfile
+
+`pg_ivm` 拡張を組み込んだ PostgreSQL 用 Docker image です。
+
+この image は [postgres](https://hub.docker.com/_/postgres/) 公式 image をベースにしており、通常の PostgreSQL image と同様に利用できます。
+
+[English README](./README.md)
+
+## クイックスタート
+
+```bash
+docker run --name postgres -e POSTGRES_PASSWORD=postgres -d -p 5432:5432 aeffix/pg_ivm:postgres16.13-pg_ivm1.13
+```
+
+## pg_ivm を簡単に試す
+
+コンテナ起動後、次の手順で `pg_ivm` をすぐ試せます。JSON を格納したテーブルを作り、その内容を参照する Incremental Materialized View を作成します。
+
+```bash
+docker exec -it postgres psql -U postgres -d postgres
+```
+
+```sql
+CREATE TABLE raw_orders (payload jsonb NOT NULL);
+
+INSERT INTO raw_orders (payload) VALUES
+  ('{"id": 1001, "customer": "alice", "amount": 1200, "status": "new"}'),
+  ('{"id": 1002, "customer": "bob", "amount": 800, "status": "paid"}');
+
+SELECT pgivm.create_immv(
+  'ivm_orders',
+  $$SELECT
+      (payload->>'id')::int AS order_id,
+      payload->>'customer' AS customer,
+      (payload->>'amount')::int AS amount,
+      payload->>'status' AS status
+    FROM raw_orders$$
+);
+
+TABLE ivm_orders;
+
+INSERT INTO raw_orders (payload)
+VALUES ('{"id": 1003, "customer": "carol", "amount": 650, "status": "shipped"}');
+
+SELECT count(*) AS row_count, sum(amount) AS total_amount FROM ivm_orders;
+```
+
+確認できること:
+
+- `TABLE ivm_orders;` で JSON から展開された行を参照できます
+- 最後の `INSERT` 実行後、`row_count` は `3` になります
+- `total_amount` は `2650` になります
+
+## 使い方
+
+以下の内容で `docker-compose.yml` を作成してください。
+
+```yaml
+version: "3.8"
+
+services:
+  db:
+    container_name: pg_ivm
+    image: aeffix/pg_ivm:postgres16.13-pg_ivm1.13
+    ports:
+      - 5432:5432
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: postgres
+    restart: always
+```
+
+その後、`docker-compose up -d` を実行すると起動できます。任意のデータベース管理ツールで `postgres` データベースへ接続し、`pg_ivm` 拡張を利用できます。
+
+詳しくは [pg_ivm の公式リポジトリ](https://github.com/sraoss/pg_ivm) を参照してください。

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This image based on [postgres](https://hub.docker.com/_/postgres/) and could use
 ## Quick start
 
 ```
-docker run --name postgres -e POSTGRES_PASSWORD=postgres -d -p 5432:5432 aeffix/pg_ivm:postgres16.4-pg_ivm1.9
+docker run --name postgres -e POSTGRES_PASSWORD=postgres -d -p 5432:5432 aeffix/pg_ivm:postgres17beta3-pg_ivm1.9
 ```
 
 ## How to use
@@ -20,7 +20,7 @@ version: "3.8"
 services:
   db:
     container_name: pg_ivm
-    image: aeffix/pg_ivm:postgres16.4-pg_ivm1.9
+    image: aeffix/pg_ivm:postgres17beta3-pg_ivm1.9
     ports:
       -   5432:5432
     environment:

--- a/README.md
+++ b/README.md
@@ -4,11 +4,52 @@ Dockerfile for extension pg_ivm.
 
 This image based on [postgres](https://hub.docker.com/_/postgres/) and could use as same as postgres images.
 
+[日本語版 README](./README.ja.md)
+
 ## Quick start
 
 ```
 docker run --name postgres -e POSTGRES_PASSWORD=postgres -d -p 5432:5432 aeffix/pg_ivm:postgres16.13-pg_ivm1.13
 ```
+
+## Try pg_ivm quickly
+
+You can test `pg_ivm` with a simple JSON-based example after the container starts.
+
+```bash
+docker exec -it postgres psql -U postgres -d postgres
+```
+
+```sql
+CREATE TABLE raw_orders (payload jsonb NOT NULL);
+
+INSERT INTO raw_orders (payload) VALUES
+  ('{"id": 1001, "customer": "alice", "amount": 1200, "status": "new"}'),
+  ('{"id": 1002, "customer": "bob", "amount": 800, "status": "paid"}');
+
+SELECT pgivm.create_immv(
+  'ivm_orders',
+  $$SELECT
+      (payload->>'id')::int AS order_id,
+      payload->>'customer' AS customer,
+      (payload->>'amount')::int AS amount,
+      payload->>'status' AS status
+    FROM raw_orders$$
+);
+
+TABLE ivm_orders;
+
+INSERT INTO raw_orders (payload)
+VALUES ('{"id": 1003, "customer": "carol", "amount": 650, "status": "shipped"}');
+
+SELECT count(*) AS row_count, sum(amount) AS total_amount FROM ivm_orders;
+```
+
+Expected result:
+
+- `TABLE ivm_orders;` returns rows extracted from JSON
+- after the last `INSERT`, `row_count` becomes `3`
+- `total_amount` becomes `2650`
 
 ## How to use
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This image based on [postgres](https://hub.docker.com/_/postgres/) and could use
 ## Quick start
 
 ```
-docker run --name postgres -e POSTGRES_PASSWORD=postgres -d -p 5432:5432 aeffix/pg_ivm:postgres17beta3-pg_ivm1.9
+docker run --name postgres -e POSTGRES_PASSWORD=postgres -d -p 5432:5432 aeffix/pg_ivm:postgres16.13-pg_ivm1.13
 ```
 
 ## How to use
@@ -20,7 +20,7 @@ version: "3.8"
 services:
   db:
     container_name: pg_ivm
-    image: aeffix/pg_ivm:postgres17beta3-pg_ivm1.9
+    image: aeffix/pg_ivm:postgres16.13-pg_ivm1.13
     ports:
       -   5432:5432
     environment:


### PR DESCRIPTION
## What changed

  - updated `16/Dockerfile` to PostgreSQL `16.13` and `pg_ivm` `v1.13`
  - updated `17/Dockerfile` to PostgreSQL `17.9` and `pg_ivm` `v1.14`
  - updated `README.md` with current image tags and a simple `pg_ivm` usage example
  - added `README.ja.md`
  - added `AGENTS.md`

  ## Why

  - keep PostgreSQL 16 and 17 images aligned with current upstream releases
  - make it easier to verify `pg_ivm` behavior with a small JSON-based example
  - provide a Japanese README for easier usage

  ## Validation

  - `docker build -t pg_ivm:16-local 16`
  - `docker build -t pg_ivm:17-local 17`
  - started both images and confirmed `pg_ivm` works with JSON input through `pgivm.create_immv(...)`
  - verified that inserted JSON rows are exposed as relational columns and that the immv updates after additional inserts