### PR TITLE
[codex] update PostgreSQL images and documentation

### DIFF
--- a/18/Dockerfile
+++ b/18/Dockerfile
@@ -1,0 +1,37 @@
+# build stage
+FROM postgres:18.3 AS builder
+
+RUN rm -f /etc/apt/apt.conf.d/docker-clean; echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update && apt-get install -y \
+    build-essential \
+    libpq-dev \
+    git \
+    postgresql-server-dev-18
+
+RUN git clone --branch v1.14 --depth 1 https://github.com/sraoss/pg_ivm.git /usr/src/pg_ivm
+
+RUN cd /usr/src/pg_ivm && \
+    make USE_PGXS=1 && \
+    make USE_PGXS=1 install
+
+# runtime stage
+FROM postgres:18.3
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p '/usr/lib/postgresql/18/lib' && \
+    mkdir -p '/usr/share/postgresql/18/extension' && \
+    mkdir -p '/usr/lib/postgresql/18/lib/bitcode/pg_ivm'
+
+COPY --from=builder /usr/lib/postgresql/18/lib/pg_ivm.so /usr/lib/postgresql/18/lib/pg_ivm.so
+COPY --from=builder /usr/share/postgresql/18/extension/pg_ivm* /usr/share/postgresql/18/extension/
+COPY --from=builder /usr/lib/postgresql/18/lib/bitcode/pg_ivm/* /usr/lib/postgresql/18/lib/bitcode/pg_ivm/
+COPY --from=builder /usr/lib/postgresql/18/lib/bitcode/pg_ivm.index.bc /usr/lib/postgresql/18/lib/bitcode/pg_ivm.index.bc
+
+COPY init-db.sh /docker-entrypoint-initdb.d/

--- a/18/init-db.sh
+++ b/18/init-db.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-EOSQL
+    CREATE EXTENSION pg_ivm;
+EOSQL

--- a/README.ja.md
+++ b/README.ja.md
@@ -9,8 +9,20 @@
 ## クイックスタート
 
 ```bash
-docker run --name postgres -e POSTGRES_PASSWORD=postgres -d -p 5432:5432 aeffix/pg_ivm:postgres16.13-pg_ivm1.13
+docker run --name postgres -e POSTGRES_PASSWORD=postgres -d -p 5432:5432 aeffix/pg_ivm:postgres18.3-pg_ivm1.14
 ```
+
+## 利用できる image tag
+
+- `aeffix/pg_ivm:postgres16.13-pg_ivm1.13`
+- `aeffix/pg_ivm:postgres17.9-pg_ivm1.14`
+- `aeffix/pg_ivm:postgres18.3-pg_ivm1.14`
+
+必要であれば、次のようなメジャーバージョン用 tag も公開できます。
+
+- `aeffix/pg_ivm:postgres16`
+- `aeffix/pg_ivm:postgres17`
+- `aeffix/pg_ivm:postgres18`
 
 ## pg_ivm を簡単に試す
 
@@ -61,7 +73,7 @@ version: "3.8"
 services:
   db:
     container_name: pg_ivm
-    image: aeffix/pg_ivm:postgres16.13-pg_ivm1.13
+    image: aeffix/pg_ivm:postgres18.3-pg_ivm1.14
     ports:
       - 5432:5432
     environment:

--- a/README.md
+++ b/README.md
@@ -9,8 +9,20 @@ This image based on [postgres](https://hub.docker.com/_/postgres/) and could use
 ## Quick start
 
 ```
-docker run --name postgres -e POSTGRES_PASSWORD=postgres -d -p 5432:5432 aeffix/pg_ivm:postgres16.13-pg_ivm1.13
+docker run --name postgres -e POSTGRES_PASSWORD=postgres -d -p 5432:5432 aeffix/pg_ivm:postgres18.3-pg_ivm1.14
 ```
+
+## Available image tags
+
+- `aeffix/pg_ivm:postgres16.13-pg_ivm1.13`
+- `aeffix/pg_ivm:postgres17.9-pg_ivm1.14`
+- `aeffix/pg_ivm:postgres18.3-pg_ivm1.14`
+
+Major-version tags can also be published for convenience:
+
+- `aeffix/pg_ivm:postgres16`
+- `aeffix/pg_ivm:postgres17`
+- `aeffix/pg_ivm:postgres18`
 
 ## Try pg_ivm quickly
 
@@ -61,7 +73,7 @@ version: "3.8"
 services:
   db:
     container_name: pg_ivm
-    image: aeffix/pg_ivm:postgres16.13-pg_ivm1.13
+    image: aeffix/pg_ivm:postgres18.3-pg_ivm1.14
     ports:
       -   5432:5432
     environment:


### PR DESCRIPTION
## What changed

- added `18/` for PostgreSQL `18.3`
- built `pg_ivm` `v1.14` against PostgreSQL 18
- updated `README.md` and `README.ja.md` with PostgreSQL 16, 17, and 18 image tags
- added a simple `pg_ivm` usage example and Japanese README
- added `AGENTS.md` contributor guidelines

## Validation

- `docker build -t pg_ivm:16-local 16`
- `docker build -t pg_ivm:17-local 17`
- `docker build -t pg_ivm:18-local 18`
- verified `pg_ivm:16-local`, `pg_ivm:17-local`, and `pg_ivm:18-local` with a JSON-based `pgivm.create_immv(...)` test
- confirmed rows are exposed as relational columns and the immv updates after an additional insert
