### PR TITLE
[codex] Support PostgreSQL 16.14, 17.10, and 18.4

### DIFF
--- a/16/Dockerfile
+++ b/16/Dockerfile
@@ -1,5 +1,5 @@
 # build stage
-FROM postgres:16.13 AS builder
+FROM postgres:16.14 AS builder
 
 RUN rm -f /etc/apt/apt.conf.d/docker-clean; echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
@@ -17,7 +17,7 @@ RUN cd /usr/src/pg_ivm && \
     make USE_PGXS=1 install
 
 # runtime stage
-FROM postgres:16.13
+FROM postgres:16.14
 
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \

--- a/17/Dockerfile
+++ b/17/Dockerfile
@@ -1,5 +1,5 @@
 # build stage
-FROM postgres:17.9 AS builder
+FROM postgres:17.10 AS builder
 
 RUN rm -f /etc/apt/apt.conf.d/docker-clean; echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
@@ -17,7 +17,7 @@ RUN cd /usr/src/pg_ivm && \
     make USE_PGXS=1 install
 
 # runtime stage
-FROM postgres:17.9
+FROM postgres:17.10
 
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \

--- a/18/Dockerfile
+++ b/18/Dockerfile
@@ -1,5 +1,5 @@
 # build stage
-FROM postgres:18.3 AS builder
+FROM postgres:18.4 AS builder
 
 RUN rm -f /etc/apt/apt.conf.d/docker-clean; echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
@@ -17,7 +17,7 @@ RUN cd /usr/src/pg_ivm && \
     make USE_PGXS=1 install
 
 # runtime stage
-FROM postgres:18.3
+FROM postgres:18.4
 
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \

--- a/README.ja.md
+++ b/README.ja.md
@@ -9,14 +9,14 @@
 ## クイックスタート
 
 ```bash
-docker run --name postgres -e POSTGRES_PASSWORD=postgres -d -p 5432:5432 aeffix/pg_ivm:postgres18.3-pg_ivm1.14
+docker run --name postgres -e POSTGRES_PASSWORD=postgres -d -p 5432:5432 aeffix/pg_ivm:postgres18.4-pg_ivm1.14
 ```
 
 ## 利用できる image tag
 
-- `aeffix/pg_ivm:postgres16.13-pg_ivm1.13`
-- `aeffix/pg_ivm:postgres17.9-pg_ivm1.14`
-- `aeffix/pg_ivm:postgres18.3-pg_ivm1.14`
+- `aeffix/pg_ivm:postgres16.14-pg_ivm1.13`
+- `aeffix/pg_ivm:postgres17.10-pg_ivm1.14`
+- `aeffix/pg_ivm:postgres18.4-pg_ivm1.14`
 
 必要であれば、次のようなメジャーバージョン用 tag も公開できます。
 
@@ -33,6 +33,10 @@ docker exec -it postgres psql -U postgres -d postgres
 ```
 
 ```sql
+CREATE EXTENSION IF NOT EXISTS pg_ivm;
+DROP TABLE IF EXISTS ivm_orders;
+DROP TABLE IF EXISTS raw_orders;
+
 CREATE TABLE raw_orders (payload jsonb NOT NULL);
 
 INSERT INTO raw_orders (payload) VALUES
@@ -59,7 +63,7 @@ SELECT count(*) AS row_count, sum(amount) AS total_amount FROM ivm_orders;
 
 確認できること:
 
-- `TABLE ivm_orders;` で JSON から展開された行を参照できます
+- `TABLE ivm_orders;` で JSON から展開された 2 行を参照できます
 - 最後の `INSERT` 実行後、`row_count` は `3` になります
 - `total_amount` は `2650` になります
 
@@ -73,7 +77,7 @@ version: "3.8"
 services:
   db:
     container_name: pg_ivm
-    image: aeffix/pg_ivm:postgres18.3-pg_ivm1.14
+    image: aeffix/pg_ivm:postgres18.4-pg_ivm1.14
     ports:
       - 5432:5432
     environment:

--- a/README.md
+++ b/README.md
@@ -9,14 +9,14 @@ This image based on [postgres](https://hub.docker.com/_/postgres/) and could use
 ## Quick start
 
 ```
-docker run --name postgres -e POSTGRES_PASSWORD=postgres -d -p 5432:5432 aeffix/pg_ivm:postgres18.3-pg_ivm1.14
+docker run --name postgres -e POSTGRES_PASSWORD=postgres -d -p 5432:5432 aeffix/pg_ivm:postgres18.4-pg_ivm1.14
 ```
 
 ## Available image tags
 
-- `aeffix/pg_ivm:postgres16.13-pg_ivm1.13`
-- `aeffix/pg_ivm:postgres17.9-pg_ivm1.14`
-- `aeffix/pg_ivm:postgres18.3-pg_ivm1.14`
+- `aeffix/pg_ivm:postgres16.14-pg_ivm1.13`
+- `aeffix/pg_ivm:postgres17.10-pg_ivm1.14`
+- `aeffix/pg_ivm:postgres18.4-pg_ivm1.14`
 
 Major-version tags can also be published for convenience:
 
@@ -33,6 +33,10 @@ docker exec -it postgres psql -U postgres -d postgres
 ```
 
 ```sql
+CREATE EXTENSION IF NOT EXISTS pg_ivm;
+DROP TABLE IF EXISTS ivm_orders;
+DROP TABLE IF EXISTS raw_orders;
+
 CREATE TABLE raw_orders (payload jsonb NOT NULL);
 
 INSERT INTO raw_orders (payload) VALUES
@@ -59,7 +63,7 @@ SELECT count(*) AS row_count, sum(amount) AS total_amount FROM ivm_orders;
 
 Expected result:
 
-- `TABLE ivm_orders;` returns rows extracted from JSON
+- `TABLE ivm_orders;` returns 2 rows extracted from JSON
 - after the last `INSERT`, `row_count` becomes `3`
 - `total_amount` becomes `2650`
 
@@ -73,7 +77,7 @@ version: "3.8"
 services:
   db:
     container_name: pg_ivm
-    image: aeffix/pg_ivm:postgres18.3-pg_ivm1.14
+    image: aeffix/pg_ivm:postgres18.4-pg_ivm1.14
     ports:
       -   5432:5432
     environment:


### PR DESCRIPTION
## What changed
Updated the PostgreSQL base image tags to 16.14, 17.10, and 18.4.
Kept pg_ivm at 1.13 for PostgreSQL 16, and kept pg_ivm at 1.14 for PostgreSQL 17 and 18.
Updated README.md and README.ja.md so the published tags and quick-start examples match the actual images.
Added a reproducible pg_ivm verification example with CREATE EXTENSION and cleanup statements.

## Why
The repository was behind the latest PostgreSQL patch releases, and the documentation still referenced older fixed tags.
The README examples also needed to match the validated image combinations for PostgreSQL 16, 17, and 18.

## Validation
- docker build -t pg_ivm:16-local 16
- docker build -t pg_ivm:17-local 17
- docker build -t pg_ivm:18-local 18
- PostgreSQL 16: pgivm.create_immv JSON example verified, row_count = 3, total_amount = 2650
- PostgreSQL 17: pgivm.create_immv JSON example verified, row_count = 3, total_amount = 2650
- PostgreSQL 18: pgivm.create_immv JSON example verified, row_count = 3, total_amount = 2650