### PR TITLE
[codex] support postgresql17.10 + pg_ivm1.15

### DIFF
--- a/17/Dockerfile
+++ b/17/Dockerfile
@@ -10,7 +10,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     git \
     postgresql-server-dev-17
 
-RUN git clone --branch v1.14 --depth 1 https://github.com/sraoss/pg_ivm.git /usr/src/pg_ivm
+RUN git clone --branch v1.15 --depth 1 https://github.com/sraoss/pg_ivm.git /usr/src/pg_ivm
 
 RUN cd /usr/src/pg_ivm && \
     make USE_PGXS=1 && \

--- a/README.ja.md
+++ b/README.ja.md
@@ -15,7 +15,7 @@ docker run --name postgres -e POSTGRES_PASSWORD=postgres -d -p 5432:5432 aeffix/
 ## 利用できる image tag
 
 - `aeffix/pg_ivm:postgres16.14-pg_ivm1.13`
-- `aeffix/pg_ivm:postgres17.10-pg_ivm1.14`
+- `aeffix/pg_ivm:postgres17.10-pg_ivm1.15`
 - `aeffix/pg_ivm:postgres18.4-pg_ivm1.14`
 
 必要であれば、次のようなメジャーバージョン用 tag も公開できます。

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ docker run --name postgres -e POSTGRES_PASSWORD=postgres -d -p 5432:5432 aeffix/
 ## Available image tags
 
 - `aeffix/pg_ivm:postgres16.14-pg_ivm1.13`
-- `aeffix/pg_ivm:postgres17.10-pg_ivm1.14`
+- `aeffix/pg_ivm:postgres17.10-pg_ivm1.15`
 - `aeffix/pg_ivm:postgres18.4-pg_ivm1.14`
 
 Major-version tags can also be published for convenience:


### PR DESCRIPTION
## What changed
- update PostgreSQL 17 image to build pg_ivm v1.15
- refresh the PostgreSQL 17 fixed image tag in README.md and README.ja.md

## Why
- keep the PostgreSQL 17 image aligned with the latest pg_ivm release

## Validation
- docker build -t pg_ivm:17-pr /tmp/pg_ivm-pr17/17