### PR TITLE
[codex] support postgresql18.4 + pg_ivm1.15

### DIFF
--- a/18/Dockerfile
+++ b/18/Dockerfile
@@ -10,7 +10,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     git \
     postgresql-server-dev-18
 
-RUN git clone --branch v1.14 --depth 1 https://github.com/sraoss/pg_ivm.git /usr/src/pg_ivm
+RUN git clone --branch v1.15 --depth 1 https://github.com/sraoss/pg_ivm.git /usr/src/pg_ivm
 
 RUN cd /usr/src/pg_ivm && \
     make USE_PGXS=1 && \

--- a/README.ja.md
+++ b/README.ja.md
@@ -9,14 +9,14 @@
 ## クイックスタート
 
 ```bash
-docker run --name postgres -e POSTGRES_PASSWORD=postgres -d -p 5432:5432 aeffix/pg_ivm:postgres18.4-pg_ivm1.14
+docker run --name postgres -e POSTGRES_PASSWORD=postgres -d -p 5432:5432 aeffix/pg_ivm:postgres18.4-pg_ivm1.15
 ```
 
 ## 利用できる image tag
 
 - `aeffix/pg_ivm:postgres16.14-pg_ivm1.13`
 - `aeffix/pg_ivm:postgres17.10-pg_ivm1.14`
-- `aeffix/pg_ivm:postgres18.4-pg_ivm1.14`
+- `aeffix/pg_ivm:postgres18.4-pg_ivm1.15`
 
 必要であれば、次のようなメジャーバージョン用 tag も公開できます。
 
@@ -77,7 +77,7 @@ version: "3.8"
 services:
   db:
     container_name: pg_ivm
-    image: aeffix/pg_ivm:postgres18.4-pg_ivm1.14
+    image: aeffix/pg_ivm:postgres18.4-pg_ivm1.15
     ports:
       - 5432:5432
     environment:

--- a/README.md
+++ b/README.md
@@ -9,14 +9,14 @@ This image based on [postgres](https://hub.docker.com/_/postgres/) and could use
 ## Quick start
 
 ```
-docker run --name postgres -e POSTGRES_PASSWORD=postgres -d -p 5432:5432 aeffix/pg_ivm:postgres18.4-pg_ivm1.14
+docker run --name postgres -e POSTGRES_PASSWORD=postgres -d -p 5432:5432 aeffix/pg_ivm:postgres18.4-pg_ivm1.15
 ```
 
 ## Available image tags
 
 - `aeffix/pg_ivm:postgres16.14-pg_ivm1.13`
 - `aeffix/pg_ivm:postgres17.10-pg_ivm1.14`
-- `aeffix/pg_ivm:postgres18.4-pg_ivm1.14`
+- `aeffix/pg_ivm:postgres18.4-pg_ivm1.15`
 
 Major-version tags can also be published for convenience:
 
@@ -77,7 +77,7 @@ version: "3.8"
 services:
   db:
     container_name: pg_ivm
-    image: aeffix/pg_ivm:postgres18.4-pg_ivm1.14
+    image: aeffix/pg_ivm:postgres18.4-pg_ivm1.15
     ports:
       -   5432:5432
     environment:


### PR DESCRIPTION
## What changed
- update PostgreSQL 18 image to build pg_ivm v1.15
- refresh the PostgreSQL 18 fixed image tag in README.md and README.ja.md
- refresh the quick start and docker-compose examples to use pg_ivm 1.15

## Why
- keep the PostgreSQL 18 image aligned with the latest pg_ivm release

## Validation
- docker build -t pg_ivm:18-pr /tmp/pg_ivm-pr18/18