### PR TITLE
[codex] add PR Docker build workflow

### DIFF
--- a/.github/workflows/pr-docker-build.yml
+++ b/.github/workflows/pr-docker-build.yml
@@ -1,0 +1,27 @@
+name: PR Docker Build
+
+on:
+  pull_request:
+
+jobs:
+  docker-build:
+    name: Build PostgreSQL ${{ matrix.pg_major }} image
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        pg_major: ["16", "17", "18"]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build image
+        uses: docker/build-push-action@v6
+        with:
+          context: ./${{ matrix.pg_major }}
+          push: false
+          tags: pg_ivm:pr-${{ matrix.pg_major }}


### PR DESCRIPTION
## What changed
- add a GitHub Actions workflow that builds the PostgreSQL 16, 17, and 18 Docker images on pull requests
- use a matrix job so all supported image directories are validated in the same workflow

## Why
- catch Dockerfile or image build regressions before merging pull requests

## Validation
- workflow file reviewed locally