### PR TITLE
[codex] copy pg_ivm dump script

### DIFF
--- a/16/Dockerfile
+++ b/16/Dockerfile
@@ -33,5 +33,6 @@ COPY --from=builder /usr/lib/postgresql/16/lib/pg_ivm.so /usr/lib/postgresql/16/
 COPY --from=builder /usr/share/postgresql/16/extension/pg_ivm* /usr/share/postgresql/16/extension/
 COPY --from=builder /usr/lib/postgresql/16/lib/bitcode/pg_ivm/* /usr/lib/postgresql/16/lib/bitcode/pg_ivm/
 COPY --from=builder /usr/lib/postgresql/16/lib/bitcode/pg_ivm.index.bc /usr/lib/postgresql/16/lib/bitcode/pg_ivm.index.bc
+COPY --from=builder /usr/lib/postgresql/16/bin/pg_ivm_dump_metadata /usr/lib/postgresql/16/bin/pg_ivm_dump_metadata
 
 COPY init-db.sh /docker-entrypoint-initdb.d/

--- a/17/Dockerfile
+++ b/17/Dockerfile
@@ -33,5 +33,6 @@ COPY --from=builder /usr/lib/postgresql/17/lib/pg_ivm.so /usr/lib/postgresql/17/
 COPY --from=builder /usr/share/postgresql/17/extension/pg_ivm* /usr/share/postgresql/17/extension/
 COPY --from=builder /usr/lib/postgresql/17/lib/bitcode/pg_ivm/* /usr/lib/postgresql/17/lib/bitcode/pg_ivm/
 COPY --from=builder /usr/lib/postgresql/17/lib/bitcode/pg_ivm.index.bc /usr/lib/postgresql/17/lib/bitcode/pg_ivm.index.bc
+COPY --from=builder /usr/lib/postgresql/17/bin/pg_ivm_dump_metadata /usr/lib/postgresql/17/bin/pg_ivm_dump_metadata
 
 COPY init-db.sh /docker-entrypoint-initdb.d/

--- a/18/Dockerfile
+++ b/18/Dockerfile
@@ -33,5 +33,6 @@ COPY --from=builder /usr/lib/postgresql/18/lib/pg_ivm.so /usr/lib/postgresql/18/
 COPY --from=builder /usr/share/postgresql/18/extension/pg_ivm* /usr/share/postgresql/18/extension/
 COPY --from=builder /usr/lib/postgresql/18/lib/bitcode/pg_ivm/* /usr/lib/postgresql/18/lib/bitcode/pg_ivm/
 COPY --from=builder /usr/lib/postgresql/18/lib/bitcode/pg_ivm.index.bc /usr/lib/postgresql/18/lib/bitcode/pg_ivm.index.bc
+COPY --from=builder /usr/lib/postgresql/18/bin/pg_ivm_dump_metadata /usr/lib/postgresql/18/bin/pg_ivm_dump_metadata
 
 COPY init-db.sh /docker-entrypoint-initdb.d/


### PR DESCRIPTION
## What changed
- copy pg_ivm_dump_metadata from the builder stage into the runtime image for PostgreSQL 16, 17, and 18

## Why
- make the pg_ivm metadata dump helper available in the published runtime images
- keep the installed pg_ivm runtime files aligned with the upstream install output

## Validation
- compared installed pg_ivm files between builder and runtime images for 16, 17, and 18
- confirmed that extension and bitcode files already matched
- rebuilt 16, 17, and 18 images and verified pg_ivm_dump_metadata exists in each runtime image